### PR TITLE
fix: delegate request to client from Workflows Service

### DIFF
--- a/knockapi/resources/workflows.py
+++ b/knockapi/resources/workflows.py
@@ -28,7 +28,7 @@ class Workflows(Service):
             'tenant': tenant
         }
 
-        return self.request("post", endpoint, payload=params)
+        return self.client.request("post", endpoint, payload=params)
 
     def cancel(self, key, cancellation_key, recipients=None):
         """
@@ -49,4 +49,4 @@ class Workflows(Service):
             'cancellation_key': cancellation_key
         }
 
-        return self.request("post", endpoint, payload=params)
+        return self.client.request("post", endpoint, payload=params)


### PR DESCRIPTION
When calling `Knock.notify`, an error is raised with the trace below.

<details>

<summary>Stacktrace</summary>

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-715b7c57babb> in <module>
----> 1 knock.notify(workflow_key="hello-world", actor=str(User.objects.get(username="evan@quaestor.com").id))

/app/notifications/client.py in notify(self, workflow_key, actor, recipients, cancellation_key, tenant, data)
     28         data: Optional[Dict] = None,
     29     ) -> None:
---> 30         self._client.notify(
     31             key=workflow_key,
     32             actor=actor,

/usr/local/lib/python3.8/site-packages/knockapi/client.py in notify(self, key, actor, recipients, data, cancellation_key, tenant)
     70         """
     71         # Note: this is essentially a delegated method
---> 72         return self.workflows.trigger(key, actor, recipients, data=data, cancellation_key=cancellation_key, tenant=tenant)

/usr/local/lib/python3.8/site-packages/knockapi/resources/workflows.py in trigger(self, key, actor, recipients, data, cancellation_key, tenant)
     29         }
     30
---> 31         return self.request("post", endpoint, payload=params)
     32
     33     def cancel(self, key, cancellation_key, recipients=None):

AttributeError: 'Workflows' object has no attribute 'request'
```

</details>

The pattern in other `Service` subclasses seems to be to call `request` on `self.client`, and I have verified that the request succeeds with this change.