### PR TITLE
fix: try and decode json, returning `None` if invalid

### DIFF
--- a/knockapi/client.py
+++ b/knockapi/client.py
@@ -23,8 +23,13 @@ class Connection(object):
             headers=self.headers,
         )
 
+        # If we got a successful response, then attempt to deserialize as JSON
         if r.ok:
-            return r.json()
+            try:
+                return r.json()
+            except ValueError:
+                return None
+
         return r.raise_for_status()
 
 


### PR DESCRIPTION
* Fixes when a response returns a `204` whereby there is no content to be deserialized

Internal issue: https://linear.app/knock/issue/KNO-1157/[python-sdk]-empty-response-causes-deserialization-error