### PR TITLE
fix(tenants): expose tenants via resources

### DIFF
--- a/knockapi/resources/__init__.py
+++ b/knockapi/resources/__init__.py
@@ -4,3 +4,4 @@ from .preferences import Preferences
 from .objects import Objects
 from .bulk_operations import BulkOperations
 from .messages import Messages
+from .tenants import Tenants

--- a/knockapi/resources/tenants.py
+++ b/knockapi/resources/tenants.py
@@ -1,7 +1,5 @@
 from .service import Service
 
-default_set_id = "default"
-
 
 class Tenants(Service):
     def list(self):


### PR DESCRIPTION
We missed exposing `from .tenants import Tenants` in our resources when we added the tenant interface.