### PR TITLE
feat(kno-2632): add support for trigger_data param

### DIFF
--- a/knockapi/resources/messages.py
+++ b/knockapi/resources/messages.py
@@ -1,5 +1,5 @@
+import json
 from .service import Service
-
 
 class Messages(Service):
     def list(self, options=None):
@@ -13,6 +13,10 @@ class Messages(Service):
             dict: a paginated list of Message records
         """
         endpoint = '/messages'
+
+        if options and options['trigger_data']:
+            options['trigger_data'] = json.dumps(options['trigger_data'])
+
         return self.client.request('get', endpoint, payload=options)
 
     def get(self, id):
@@ -52,6 +56,10 @@ class Messages(Service):
             dict: paginated Activity response from Knock.
         """
         endpoint = '/messages/{}/activities'.format(id)
+
+        if options and options['trigger_data']:
+            options['trigger_data'] = json.dumps(options['trigger_data'])
+
         return self.client.request('get', endpoint, options)
 
     def get_events(self, id, options=None):

--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -1,3 +1,4 @@
+import json
 from .service import Service
 
 default_set_id = "default"
@@ -150,6 +151,10 @@ class Objects(Service):
             dict: Paginated Message response.
         """
         endpoint = '/objects/{}/{}/messages'.format(collection, id)
+
+        if options and options['trigger_data']:
+            options['trigger_data'] = json.dumps(options['trigger_data'])
+
         return self.client.request('get', endpoint, payload=options)
 
     ##

--- a/knockapi/resources/users.py
+++ b/knockapi/resources/users.py
@@ -1,3 +1,4 @@
+import json
 from .service import Service
 from warnings import warn
 
@@ -91,6 +92,10 @@ class User(Service):
             dict: A Knock feed response
         """
         endpoint = '/users/{}/feeds/{}'.format(user_id, channel_id)
+
+        if options and options['trigger_data']:
+            options['trigger_data'] = json.dumps(options['trigger_data'])
+
         return self.client.request('get', endpoint, payload=options)
 
     def merge(self, user_id, from_user_id):


### PR DESCRIPTION
Add support for the `trigger_data` param on the following endpoints:

* Messages list
* Message activities
* User messages
* Object messages
* User feed

