### PR TITLE
feat(kno-3766):  add subscriptions support

### DIFF
--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -19,6 +19,23 @@ class Objects(Service):
         endpoint = '/objects/{}/{}'.format(collection, id)
         return self.client.request('get', endpoint)
 
+    def list(self, collection, options={}):
+        """
+        Returns objects in collection for the provided environment
+
+        Args:
+            collection (str): The collection the object belongs to
+            options (dict): An optional set of filtering options to pass to the query. These are:
+                - page_size: specify size of the page to be returned by the api. (max limit: 50)
+                - after:  after cursor for pagination
+                - before: before cursor for pagination
+
+        Returns:
+            dict: Paginated Knock Object response.
+        """
+        endpoint = '/objects/{}'.format(collection)
+        return self.client.request('get', endpoint, payload=options)
+
     # NOTE: This is `set_object` as `set` is a reserved keyword
     def set_object(self, collection, id, data={}):
         """

--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -428,3 +428,78 @@ class Objects(Service):
             'subscribed': setting}
 
         return self.client.request('put', endpoint, payload=params)
+
+    ##
+    # Subscriptions
+    ##
+
+    def list_subscriptions(self, collection, id, options={}):
+        """
+        Returns subscriptions for an object
+
+        Args:
+            collection (str): The collection the object belongs to
+            id (str): The id of the object
+            options (dict): An optional set of filtering options to pass to the query. These are:
+                - page_size: specify size of the page to be returned by the api. (max limit: 50)
+                - after:  after cursor for pagination
+                - before: before cursor for pagination
+
+        Returns:
+            dict: Paginated Subscription response.
+        """
+        endpoint = '/objects/{}/{}/subscriptions'.format(collection, id)
+        return self.client.request('get', endpoint, payload=options)
+
+    def get_subscriptions(self, collection, id, options={}):
+        """
+        Returns subscriptions for an object as a recipient
+
+        Args:
+            collection (str): The collection the object belongs to
+            id (str): The id of the object
+            options (dict): An optional set of filtering options to pass to the query. These are:
+                - page_size: specify size of the page to be returned by the api. (max limit: 50)
+                - after:  after cursor for pagination
+                - before: before cursor for pagination
+
+        Returns:
+            dict: Paginated Subscription response.
+        """
+
+        options['mode'] = 'recipient'
+        endpoint = '/objects/{}/{}/subscriptions'.format(collection, id)
+        return self.client.request('get', endpoint, payload=options)
+
+    def add_subscriptions(self, collection, id, recipients, properties={}):
+        """
+        Creates or update subscription for recipients to Object
+
+        Args:
+            collection (str): The collection the object belongs to
+            id (str): The id of the object
+            recipients(list): List of recipients to be subscribed to object
+            properties (dict): Properties to be set on the subscription
+
+        Returns:
+            list: List of Subscription response.
+        """
+
+        endpoint = '/objects/{}/{}/subscriptions'.format(collection, id)
+        return self.client.request('post', endpoint, payload={'recipients': recipients, 'properties': properties})
+
+    def delete_subscriptions(self, collection, id, recipients):
+        """
+        Delete subscription to object for recipients
+
+        Args:
+            collection (str): The collection the object belongs to
+            id (str): The id of the object
+            recipients(list): List of recipients for subscriptions to be deleted
+
+        Returns:
+            list: List of Subscription response.
+        """
+
+        endpoint = '/objects/{}/{}/subscriptions'.format(collection, id)
+        return self.client.request('delete', endpoint, payload={'recipients': recipients})

--- a/knockapi/resources/users.py
+++ b/knockapi/resources/users.py
@@ -441,3 +441,24 @@ class User(Service):
         """
         endpoint = '/users/{}/schedules'.format(id)
         return self.client.request('get', endpoint, payload=options)
+
+    ##
+    # Subscriptions
+    ##
+
+    def get_subscriptions(self, id, options=None):
+        """
+        Get user's subscriptions
+
+        Args:
+            id (str): The user ID
+            options (dict): An optional set of filtering options to pass to the query. These are:
+                - page_size: specify size of the page to be returned by the api. (max limit: 50)
+                - after:  after cursor for pagination
+                - before: before cursor for pagination
+
+        Returns:
+            dict: Paginated Subscription response.
+        """
+        endpoint = '/users/{}/subscriptions'.format(id)
+        return self.client.request('get', endpoint, payload=options)

--- a/knockapi/resources/users.py
+++ b/knockapi/resources/users.py
@@ -24,6 +24,22 @@ class User(Service):
         endpoint = '/users/{}'.format(id)
         return self.client.request('get', endpoint)
 
+    def list(self, options={}):
+        """
+        List users for the environment
+
+        Args:
+            options (dict): An optional set of filtering options to pass to the query. These are:
+                - page_size: specify size of the page to be returned by the api. (max limit: 50)
+                - after:  after cursor for pagination
+                - before: before cursor for pagination
+
+        Returns:
+            dict: Paginated User response.
+        """
+        endpoint = '/users'
+        return self.client.request('get', endpoint, payload=options)
+
     def identify(self, id, data={}):
         """
         Identify a user, upserting them


### PR DESCRIPTION
Adds support for subscription endpoints:
* Add subscriptions to objects
* Delete subscriptions
* List subscription for object
* Get subscriptions for object as recipient
* Get subscriptions for user

Also adds missing support for:
* List users for environment
* List objects by collection for environment