### PR TITLE
Chore: Update description for get_subscriptions method

### DIFF
--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -453,7 +453,7 @@ class Objects(Service):
 
     def get_subscriptions(self, collection, id, options={}):
         """
-        Returns all of the active subscriptions that the specified object is subscribed to (not the subscribers of the object)
+        Returns all of the active subscriptions for which the specified object is a recipient
         
         Args:
             collection (str): The collection the object belongs to

--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -453,8 +453,8 @@ class Objects(Service):
 
     def get_subscriptions(self, collection, id, options={}):
         """
-        Returns subscriptions for an object as a recipient
-
+        Returns all of the active subscriptions that the specified object is subscribed to (not the subscribers of the object)
+        
         Args:
             collection (str): The collection the object belongs to
             id (str): The id of the object


### PR DESCRIPTION
Updates the description for the `get_subscriptions` method, as it's unclear that the method uses the `?mode=recipient` query parameter, thus returning a list of active subscriptions that the specified object itself is subscribed to (*not* returning a list of recipients who are subscribed to that object, which is what the `list_subscription` method accomplishes). 
