### PR TITLE
fix: update default value for schedule repeats

### DIFF
--- a/knockapi/resources/workflows.py
+++ b/knockapi/resources/workflows.py
@@ -76,7 +76,7 @@ class Workflows(Service):
             self,
             key,
             recipients,
-            repeats=None,
+            repeats=[],
             scheduled_at=None,
             data={},
             actor=None,


### PR DESCRIPTION
### Description

Update the default value for the `repeats` param when creating a schedule.