### PR TITLE
feat: add message delivery logs method

### DIFF
--- a/knockapi/resources/messages.py
+++ b/knockapi/resources/messages.py
@@ -130,7 +130,7 @@ class Messages(Service):
             id: The message ID
 
         Returns:
-            dict: paginated Delivery Log response from Knock.
+            dict: paginated MessageDeliveryLog response from Knock.
         """
         endpoint = '/messages/{}/delivery_logs'.format(id)
         return self.client.request('get', endpoint, options)

--- a/knockapi/resources/messages.py
+++ b/knockapi/resources/messages.py
@@ -121,3 +121,16 @@ class Messages(Service):
         """
         endpoint = '/messages/{}/events'.format(id)
         return self.client.request('get', endpoint, options)
+
+    def get_delivery_logs(self, id, options=None):
+        """
+        Get a message's delivery logs by its id
+
+        Args:
+            id: The message ID
+
+        Returns:
+            dict: paginated Delivery Log response from Knock.
+        """
+        endpoint = '/messages/{}/delivery_logs'.format(id)
+        return self.client.request('get', endpoint, options)


### PR DESCRIPTION
Adds a method for getting message delivery logs, based on: https://docs.knock.app/reference#get-message-delivery-logs