### PR TITLE
Add ability to set a timeout on api requests

### DIFF
--- a/knockapi/client.py
+++ b/knockapi/client.py
@@ -5,7 +5,7 @@ __version__ = '0.5.10'
 
 
 class Connection(object):
-    def __init__(self, api_key, host='https://api.knock.app'):
+    def __init__(self, api_key, host='https://api.knock.app', timeout=None):
         self.api_key = api_key
         self.host = host
         self.client_version = __version__
@@ -13,6 +13,7 @@ class Connection(object):
             'Authorization': 'Bearer {}'.format(self.api_key),
             'User-Agent': 'Knock Python - {}'.format(self.client_version)
         }
+        self.timeout = timeout
 
     def request(self, method, endpoint, payload=None, options={}):
         url = '{}/v1{}'.format(self.host, endpoint)
@@ -26,7 +27,8 @@ class Connection(object):
             url,
             params=payload if method == 'get' else None,
             json=payload if method != 'get' else None,
-            headers={**self.headers, **extra_headers}
+            headers={**self.headers, **extra_headers},
+            timeout=self.timeout,
         )
 
         # If we got a successful response, then attempt to deserialize as JSON


### PR DESCRIPTION
Added a `timeout` parameter to the `Connection` class in `knockapi/client.py`, enabling timeout configuration for API requests.
- `Connection.__init__` now accepts a `timeout` parameter.
- `Connection.request` updated to use the `timeout` parameter for HTTP requests.

example usage:

```
client = Knock(api_key="foo", timeout=10)
```