### PR TITLE
fix: correct object to objects in bulk_add_subscriptions

### DIFF
--- a/knockapi/resources/objects.py
+++ b/knockapi/resources/objects.py
@@ -502,7 +502,7 @@ class Objects(Service):
             dict: BulkOperation from Knock
         """
 
-        endpoint = '/object/{}/bulk/subscriptions/add'.format(collection)
+        endpoint = '/objects/{}/bulk/subscriptions/add'.format(collection)
         return self.client.request('post', endpoint, payload={'subscriptions': subscriptions})
 
     def delete_subscriptions(self, collection, id, recipients):


### PR DESCRIPTION
This PR fixes a simple typo in `objects.bulk_add_subscriptions` where the url uses the singular `/object/` instead of `/objects/`.