### PR TITLE
Allow an option to Force Pydantic V1 model

### DIFF
--- a/src/knockapi/_compat.py
+++ b/src/knockapi/_compat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any, Union, Generic, TypeVar, Callable, cast, overload
 from datetime import date, datetime
 from typing_extensions import Self, Literal
@@ -17,7 +18,7 @@ _ModelT = TypeVar("_ModelT", bound=pydantic.BaseModel)
 # Pyright incorrectly reports some of our functions as overriding a method when they don't
 # pyright: reportIncompatibleMethodOverride=false
 
-PYDANTIC_V1 = pydantic.VERSION.startswith("1.")
+PYDANTIC_V1 = pydantic.VERSION.startswith("1.") or os.environ.get("FORCE_PYDANTIC_V1", "").lower() in ("1", "true")
 
 if TYPE_CHECKING:
 


### PR DESCRIPTION
Currently, if Pydantic V2 is available in the environment, `knockapi` automatically uses Pydantic V2 model validation. This makes it difficult to take advantage of Pydantic's gradual migration approach. As first step to Pydantic V1 --> V2 upgrade, we want to install Pydantic V2 in our system, while keeping all of our models in V1. However, since some of the `knockapi` models we reference will automatically become V2 models due to the presence of the Pydantic V2 binary in the system, the side by side approach is getting a bit complex.

This PR adds an env var `FORCE_PYDANTIC_V1`  to allow for a mechanism to make `knockapi` use V1 codepaths, even when V2 is installed in the system  